### PR TITLE
Use GFM instead of kramdown for rendering markdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,6 @@
-markdown: kramdown
+markdown: CommonMarkGhPages
+# see https://github.com/github/pages-gem/blob/1cb8d3b5e634798e9a4b97042652318dc438e25b/lib/github-pages/configuration.rb#L154
+commonmark:
+  extensions: ["table", "strikethrough", "autolink", "tagfilter"]
+  options: ["footnotes"]
 highlighter: rouge


### PR DESCRIPTION
The only markdown file rendered is `README.md`. The default renderer is `kramdown`, but I assume that most people write this file using GFM (GitHub Flavored Markdown).

Example: https://homalg-project.github.io/SubcategoriesForCAP/README.html This would not render correctly using `kramdown`, but renders correctly using GFM: https://github.com/homalg-project/SubcategoriesForCAP/commit/0509c8f9c10f465c76cd03b133a80be51d9fd11b

GitHub documentation: https://docs.github.com/en/github/working-with-github-pages/setting-a-markdown-processor-for-your-github-pages-site-using-jekyll

