### PR TITLE
Add the `CHANGES` file to `_data/package.yml` (like `README`)

### DIFF
--- a/update.g
+++ b/update.g
@@ -136,6 +136,9 @@ GeneratePackageYML:=function(pkg)
     tmp := SplitString(pkg.README_URL,"/");
     tmp := tmp[Length(tmp)];  # extract README filename (typically "README" or "README.md")
     AppendTo(stream, "readme: ", tmp, "\n");
+    tmp := SplitString(pkg.CHANGES_URL,"/");
+    tmp := tmp[Length(tmp)];  # extract CHANGES filename (typically "CHANGES", "CHANGES.md", or "CHANGELOG.md")
+    AppendTo(stream, "changes: ", tmp, "\n");
     AppendTo(stream, "packageinfo: ", pkg.PackageInfoURL, "\n");
     if IsBound(pkg.GithubWWW) then
         AppendTo(stream, "github: ", pkg.GithubWWW, "\n");


### PR DESCRIPTION
For the Semigroups and Digraphs packages, we like to include our `CHANGELOG.md` files on our websites. I want these to be automatically kept up to date by the usual automation tools. This is a step in that direction.

See https://github.com/gap-system/ReleaseTools/issues/108 and https://github.com/gap-packages/example/pull/46.