### PR TITLE
Add `doc/index.md` to redirect `doc/` to the title page of the manual

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,12 @@
+---
+layout: null
+---
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=../{{site.data.package.doc-html}}" />
+    <title>The manual</title>
+  </head>
+  <body>
+    <a href="../{{site.data.package.doc-html}}">Click to access the title page of the manual.</a>
+  </body>
+</html>


### PR DESCRIPTION
Perhaps there are nicer ways of doing this, I'm not sure. But at least this doesn't use javascript. I'm using this already for Digraphs: https://digraphs.github.io/Digraphs/doc/

Resolves #24.