### PR TITLE
Keep doc/index.md out of doc folder

### DIFF
--- a/doc-index.md
+++ b/doc-index.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+permalink: /doc/index.html
 ---
 <html>
   <head>


### PR DESCRIPTION
This should still create the `doc/index.html` file, but by keeping the `.md` file outside the doc folder we can safely replace this entire folder, e.g. in the `update-gh-pages` action (see https://github.com/gap-actions/update-gh-pages/issues/10).